### PR TITLE
Static content update to staging branch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8123,8 +8123,8 @@
     },
     "node_modules/static-content-cannabis-staging": {
       "name": "static-content-cannabis",
-      "version": "2.0.1051",
-      "resolved": "git+ssh://git@github.com/cagov/static-content-cannabis.git#3b4ebb4be62e942787f2f7c30e1e2bcf745c7b50"
+      "version": "2.0.1127",
+      "resolved": "git+ssh://git@github.com/cagov/static-content-cannabis.git#169a3d602c9c53b8cd7b4577c4c7168e60bb9b1e"
     },
     "node_modules/statuses": {
       "version": "2.0.1",
@@ -15241,7 +15241,7 @@
       "from": "static-content-cannabis@github:cagov/static-content-cannabis#main"
     },
     "static-content-cannabis-staging": {
-      "version": "git+ssh://git@github.com/cagov/static-content-cannabis.git#3b4ebb4be62e942787f2f7c30e1e2bcf745c7b50",
+      "version": "git+ssh://git@github.com/cagov/static-content-cannabis.git#169a3d602c9c53b8cd7b4577c4c7168e60bb9b1e",
       "from": "static-content-cannabis-staging@github:cagov/static-content-cannabis#staging"
     },
     "statuses": {


### PR DESCRIPTION
Method: api.testmj.com (WordPress REST API, Pantheon), content tagged "staging" > @mukkhtarr/cannabis-lambda-sync-github (AWS CloudFormation, arc.codes) > @mukkhtarr/static-content-cannabis-staging (Static content repo, staging branch)