### PR TITLE
Static content update to staging branch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8125,7 +8125,7 @@
     "node_modules/static-content-cannabis-staging": {
       "name": "static-content-testmj",
       "version": "2.0.1058",
-      "resolved": "git+ssh://git@github.com/mukkhtarr/static-content-testmj.git#7078854a7ccc31a865f38b17e81324f24e675f2d"
+      "resolved": "git+ssh://git@github.com/mukkhtarr/static-content-testmj.git#9ac5d34a757752f6bcb060b69ce727d277436e99"
     },
     "node_modules/statuses": {
       "version": "2.0.1",
@@ -15242,7 +15242,7 @@
       "from": "static-content-cannabis@github:mukkhtarr/static-content-testmj#main"
     },
     "static-content-cannabis-staging": {
-      "version": "git+ssh://git@github.com/mukkhtarr/static-content-testmj.git#7078854a7ccc31a865f38b17e81324f24e675f2d",
+      "version": "git+ssh://git@github.com/mukkhtarr/static-content-testmj.git#9ac5d34a757752f6bcb060b69ce727d277436e99",
       "from": "static-content-cannabis-staging@github:mukkhtarr/static-content-testmj#staging"
     },
     "statuses": {


### PR DESCRIPTION
Method: api.testmj.com (WordPress REST API, Pantheon), content tagged "staging" > @mukkhtarr/cannabis-lambda-sync-github (AWS CloudFormation, arc.codes) > @mukkhtarr/static-content-cannabis-staging (Static content repo, staging branch)