### PR TITLE
Static content update to staging branch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8125,7 +8125,7 @@
     "node_modules/static-content-cannabis-staging": {
       "name": "static-content-testmj",
       "version": "2.0.1058",
-      "resolved": "git+ssh://git@github.com/mukkhtarr/static-content-testmj.git#3aff0e3d804fbd82366b985aa91709c3e6adda29"
+      "resolved": "git+ssh://git@github.com/mukkhtarr/static-content-testmj.git#2776d26a473b9205dcdf0f41af12a42c8d81be97"
     },
     "node_modules/statuses": {
       "version": "2.0.1",
@@ -15242,7 +15242,7 @@
       "from": "static-content-cannabis@github:mukkhtarr/static-content-testmj#main"
     },
     "static-content-cannabis-staging": {
-      "version": "git+ssh://git@github.com/mukkhtarr/static-content-testmj.git#3aff0e3d804fbd82366b985aa91709c3e6adda29",
+      "version": "git+ssh://git@github.com/mukkhtarr/static-content-testmj.git#2776d26a473b9205dcdf0f41af12a42c8d81be97",
       "from": "static-content-cannabis-staging@github:mukkhtarr/static-content-testmj#staging"
     },
     "statuses": {


### PR DESCRIPTION
Method: api.testmj.com (WordPress REST API, Pantheon), content tagged "staging" > @mukkhtarr/cannabis-lambda-sync-github (AWS CloudFormation, arc.codes) > @mukkhtarr/static-content-cannabis-staging (Static content repo, staging branch)