### PR TITLE
Static content update to staging branch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8125,7 +8125,7 @@
     "node_modules/static-content-cannabis-staging": {
       "name": "static-content-testmj",
       "version": "2.0.1058",
-      "resolved": "git+ssh://git@github.com/mukkhtarr/static-content-testmj.git#ef9ce69d25cb8fc321df5529573d923b7da8dd9b"
+      "resolved": "git+ssh://git@github.com/mukkhtarr/static-content-testmj.git#5ae0637e86729ad3ba23063398cf9137fecdca77"
     },
     "node_modules/statuses": {
       "version": "2.0.1",
@@ -15242,7 +15242,7 @@
       "from": "static-content-cannabis@github:mukkhtarr/static-content-testmj#main"
     },
     "static-content-cannabis-staging": {
-      "version": "git+ssh://git@github.com/mukkhtarr/static-content-testmj.git#ef9ce69d25cb8fc321df5529573d923b7da8dd9b",
+      "version": "git+ssh://git@github.com/mukkhtarr/static-content-testmj.git#5ae0637e86729ad3ba23063398cf9137fecdca77",
       "from": "static-content-cannabis-staging@github:mukkhtarr/static-content-testmj#staging"
     },
     "statuses": {


### PR DESCRIPTION
Method: api.testmj.com (WordPress REST API, Pantheon), content tagged "staging" > @mukkhtarr/cannabis-lambda-sync-github (AWS CloudFormation, arc.codes) > @mukkhtarr/static-content-cannabis-staging (Static content repo, staging branch)